### PR TITLE
When converting from md to html, adding "inline" class for a single b…

### DIFF
--- a/css/aitn.css
+++ b/css/aitn.css
@@ -24,6 +24,15 @@ code {
     box-shadow: 2px 2px 8px #666;
 }
 
+code.inline {
+    display: inline-block;
+    border-radius: 5px;
+    padding: 3px !important;
+    box-shadow: 1px 1px 4px #666;    
+    background: #333;
+    color: #ddd;    
+}
+
 table {
     border-collapse: collapse;
 }

--- a/js/Markdown.Converter.js
+++ b/js/Markdown.Converter.js
@@ -1047,7 +1047,8 @@ else
                     c = c.replace(/[ \t]*$/g, ""); // trailing whitespace
                     c = _EncodeCode(c);
                     c = c.replace(/:\/\//g, "~P"); // to prevent auto-linking. Not necessary in code *blocks*, but in code spans. Will be converted back after the auto-linker runs.
-                    return m1 + "<code>" + c + "</code>";
+                    var className = m2 == '`' ? 'inline' : '';
+                    return m1 + '<code class="'+className+'">' + c + '</code>';
                 }
             );
 

--- a/js/highlight.plus.markdown.js
+++ b/js/highlight.plus.markdown.js
@@ -6,14 +6,8 @@ $(document).ready(function () {
     var formatted = converter.makeHtml(md);
     element.textContent = "";
     element.innerHTML = formatted;
-    $(element).find('code').each(function(i, block) {
+    $(element).find('code:not(.inline)').each(function(i, block) {
       hljs.highlightBlock(block);
-      /* if inline, element style should be:
-         display: inline;
-         border-radius: 5px;
-         padding: 3px !important;
-         box-shadow: 1px 1px 4px #666;
-      */
     });
     $(element).css('display','inline-block');
   });


### PR DESCRIPTION
…acktick, and using syntax highlighting only for code blocks (of three backticks)